### PR TITLE
Make sure old installer will be replaced

### DIFF
--- a/deposit/depositHandler.go
+++ b/deposit/depositHandler.go
@@ -99,7 +99,7 @@ func (dh *Handler) store(deposit *Deposit) (*Response, error) {
 		PairingCode: id,
 	}
 	response.Expires = time.Now().UTC().Add(ttl)
-	response.Installers.Linux = fmt.Sprintf(`curl -JO %s/%s
+	response.Installers.Linux = fmt.Sprintf(`curl %s/%s > rport-installer.sh
 sudo sh rport-installer.sh`, dh.ServerUrl, id)
 	response.Installers.Windows = fmt.Sprintf(`[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $url="%s/%s"


### PR DESCRIPTION
Reason :
Tested in Ubuntu 20.04, curl command isn't replace old installer when user curl that more than 2 times especially with different data like password

Solution :
Change installer respon to make sure that will be replaced
